### PR TITLE
Set openerTabId for new tabs.

### DIFF
--- a/addon/background_scripts/index.js
+++ b/addon/background_scripts/index.js
@@ -15,6 +15,9 @@ async function createTab (props) {
   if (options.defaultPosition === LEFT) {
     position = tabs[0].index
   }
+  if (options.defaultPosition === RIGHT) {
+    props.openerTabId = tabs[0].id
+  }
   if (options.defaultPosition === FIRST) {
     position = 0
   }


### PR DESCRIPTION
It will help some addons to detect new tabs as children of the source tab. (for example, Tree Style Tab)
See also: https://github.com/piroor/treestyletab/issues/1668
