### PR TITLE
Fix to set default when option is undefined

### DIFF
--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -40,6 +40,6 @@ export async function loadOptions() {
   if (isEmpty(storage) || Object.keys(storage).length === 0) {
     return DEFAULT_OPTIONS
   } else {
-    return storage.options
+    return { ...DEFAULT_OPTIONS, ...storage.options }
   }
 }


### PR DESCRIPTION
Addon does not work when loading options with `whitelist` undefined.